### PR TITLE
Add Norsk Ode cinematic prompt template

### DIFF
--- a/Norsk_Ode_E_Prompt_Template.md
+++ b/Norsk_Ode_E_Prompt_Template.md
@@ -1,0 +1,37 @@
+# E-Prompt Template: Norsk Ode (Cinematic Sequence)
+
+This template guides a video-generation model to create a historically grounded, high-fidelity cinematic sequence in 1798 Setesdal, Norway.
+
+## 1. Core Scene & Emotional Context
+
+| Category | Detail |
+| :--- | :--- |
+| **Scene Type** | Historical Realism · Execution Scene · 1798 Norway |
+| **Location** | Setesdal Valley, Agder County, Southern Norway |
+| **Time of Day** | Pre-dawn to sunrise (heavy, cold light) |
+| **Style** | Cold cinematic lighting · Heavy air · Nordic melancholy · Gritty realism |
+| **Mood Keywords** | **Guilt** · **Fate** · **Dawn fog** · **Crowd judgment** · **Chains** · **Frost** · **Decapitation** |
+| **Historical Detail** | Execution method: **decapitation** with an axe at the rettersted; Sigurd is a condemned criminal led to the site for capital punishment. |
+
+## 2. Sequence Outline (Shot-by-Shot Prompts)
+
+| Shot | Description | Prompt Focus (for AI) |
+| :--- | :--- | :--- |
+| **Shot 1: Wide Establishing Shot** | Wide shot of the Setesdal valley at sunrise. Heavy, low-hanging mist lifting from the river (Otra or tributary). Rugged, forested, frost-covered terrain with a crude execution platform in the distance and a gathering crowd. | `Wide shot, Setesdal valley Norway, 1798, sunrise, heavy dawn fog, frost on ground, river mist, rugged landscape, cold cinematic grade, high dynamic range.` |
+| **Shot 2: Medium Shot – The Procession** | Medium shot of the condemned, Sigurd Sødal, dragged through mud in heavy iron chains, head bowed. The crowd forms a hostile ring, yelling and jeering. Emphasize muddy textures, visible breath in cold air, and rough 1790s folk garments. | `Medium shot, Sigurd Sødal, 1790s Norwegian folk garments, iron chains, muddy ground, hostile crowd judgment, heavy air, cold light, breath fog, extreme detail on textures.` |
+| **Shot 3: Close-Up – The Condemned** | Extreme close-up on Sigurd's eyes reflecting fate and guilt. A dried patch of blood on his temple hints at struggle. Lips move in a silent whisper. | `Extreme close-up, male eyes, blood on temple, profound guilt, acceptance of fate, subsurface skin detail, cold cinematic lighting, shallow depth of field.` |
+| **Shot 4: Dialogue/Sound Transition** | Audio: barely audible whisper in Norwegian, *«Jeg heter Sigurd. Dette er slutten.»* (My name is Sigurd. This is the end.) Sound cuts abruptly to silence. Visual: hold on the close-up, then fade to black. | `Hold on close-up, audio whisper in Norwegian, abrupt cut to silence, fade to black.` |
+| **Shot 5: Title Card** | Silence continues. A stark white title appears against black: *Norsk Ode*. | `Cut to title card: "Norsk Ode". Stark, white, minimalist font on black background.` |
+| **Shot 6: Final Voiceover** | As title fades, a deep, resonant voice-over begins. | `Voice-over: «Dør du, blir du din egen etterforsker.» (If you die, you become your own investigator.)` |
+
+## 3. Visual Prompt Additions (Technical & Aesthetic)
+
+| Parameter | Detail |
+| :--- | :--- |
+| **Visual Quality** | Realistic cinematic grade, Unreal Engine look, global illumination, subsurface scattering for skin, 8K fog volumes for dense atmosphere. |
+| **Texture & Detail** | Burned wood textures for the platform, muddy clothing and ground, frost and rime detail. |
+| **Costuming** | Norwegian folk garments, late 1700s Setesdal style: heavy wool, dark practical colors suited to cold climate. |
+| **Camera/Lens** | Shot on Arri Alexa 65, anamorphic lens, low angles for power and drama, natural film grain. |
+| **Color Grade** | Desaturated, cool tones with heavy contrast and deep shadows. |
+
+Use these prompts sequentially to generate a cohesive, melancholic historical execution sequence rooted in Nordic realism.


### PR DESCRIPTION
## Summary
- add detailed Norsk Ode cinematic e-prompt covering historical execution sequence in 1798 Setesdal
- include shot-by-shot guidance, mood, technical parameters, and voiceover cues

## Testing
- not run (documentation-only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927fa78d0f48328ae10d9cb904695fa)