### PR TITLE
Add Norwegian Venom project kickoff to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # Creed-of-the-red-dead
 I want to base the game file for rdr2 and baSic it on all the members backgrounds, dulling the missing storyline eit ai and imagination. The basic codeing, ill let THE AI do for
+
+## Norwegian Venom (project kickoff)
+A fresh game concept in this repo. This section is a starting point so we can align on vision, scope, and the next concrete build steps.
+
+### Vision
+A story-driven action game set in Norway, blending modern noir with folk-horror themes. The player becomes "Venom"—a vigilante shaped by betrayal and mythic forces.
+
+### Pillars
+- **Nordic noir** atmosphere: cold landscapes, isolation, and moral ambiguity.
+- **Myth-meets-modern** narrative: folklore influences missions, enemies, and environments.
+- **Tactical action**: close-quarters combat + stealth + environmental tools.
+- **Character-driven story**: choices affect alliances and the final outcome.
+
+### MVP (first playable slice)
+- **One hub area** (small coastal town with a forest edge).
+- **Two core mechanics**: stealth takedown + environmental distraction.
+- **One quest line**: investigate a disappearance tied to a local legend.
+- **Basic UI**: mission tracker + inventory slots.
+
+### Initial tasks
+1. **Game design doc (GDD) outline**
+   - Story synopsis, characters, locations, mechanics, progression.
+2. **Art direction board**
+   - References for environments, lighting, character silhouettes.
+3. **Prototype plan**
+   - Decide engine (Unity/Unreal/Godot), prototype goals, and milestones.
+
+### Questions to lock down
+- What genre focus do you want (action/stealth/RPG/survival)?
+- Realistic modern Norway vs. stylized mythic world?
+- Single-player only, or co-op?
+- Preferred engine and target platform?


### PR DESCRIPTION
### Motivation
- Add a project kickoff to capture vision, scope, and next steps for a new game concept called Norwegian Venom.
- Provide a shared starting point to align decisions about genre, setting, and engine choice.

### Description
- Add a `Norwegian Venom (project kickoff)` section to `README.md` that includes `Vision`, `Pillars`, `MVP`, `Initial tasks`, and `Questions to lock down`.
- Define MVP goals such as a hub area, two core mechanics, one quest line, and a basic UI.
- List initial tasks including a GDD outline, art direction board, and a prototype plan.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d38cd93548328b389cb6b44556d05)